### PR TITLE
Fix issue with cumulated precision error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.vscode/
+build/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,0 @@
-.vscode/
-build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.12)
+
+project(polylineencoder)
+set (CMAKE_CXX_STANDARD 11)
+
+add_library(encoder
+  src/polylineencoder.cpp
+)
+
+add_executable(poly_test
+  test/main.cpp
+)
+
+target_link_libraries(poly_test
+  PRIVATE encoder
+)
+
+enable_testing()
+add_test(NAME Test COMMAND poly_test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project(polylineencoder)
 set (CMAKE_CXX_STANDARD 11)
 
 add_library(encoder
+  src/polylineencoder.h
   src/polylineencoder.cpp
 )
 

--- a/src/polylineencoder.cpp
+++ b/src/polylineencoder.cpp
@@ -48,13 +48,11 @@ std::string PolylineEncoder::encode() const
     return encode(m_polyline);
 }
 
-std::string PolylineEncoder::encode(double value)
+std::string PolylineEncoder::encode(int32_t e5)
 {
-    int32_t e5 = std::round(value * s_presision); // (2)
-
     e5 <<= 1;                                     // (4)
 
-    if (value < 0) {
+    if (e5 < 0) {
         e5 = ~e5;                                 // (5)
     }
 
@@ -83,14 +81,14 @@ std::string PolylineEncoder::encode(const PolylineEncoder::Polyline &polyline)
 {
     std::string result;
 
-    // The first segment: offset from (.0, .0)
-    double latPrev = .0;
-    double lonPrev = .0;
+    // The first segment: offset from (0, 0)
+    int32_t latPrev = 0;
+    int32_t lonPrev = 0;
 
     for (const auto &tuple : polyline)
     {
-      const auto lat = std::get<0>(tuple);
-      const auto lon = std::get<1>(tuple);
+      const auto lat = std::round(std::get<0>(tuple) * s_presision); // (2)
+      const auto lon = std::round(std::get<1>(tuple) * s_presision); // (2)
 
       // Offset from the previous point
       result.append(encode(lat - latPrev));

--- a/src/polylineencoder.cpp
+++ b/src/polylineencoder.cpp
@@ -38,7 +38,10 @@ static const int    s_6bitMask    = 0x20; // 0b100000 = 32
 PolylineEncoder::Point::Point(double latitude, double longitude)
     : m_latitude(std::round(latitude * s_presision) / s_presision)
     , m_longitude(std::round(longitude * s_presision) / s_presision)
-{}
+{
+    assert(latitude <= 90.0 && latitude >= -90.0);
+    assert(longitude <= 180.0 && longitude >= -180.0);
+}
 
 double PolylineEncoder::Point::latitude() const
 {

--- a/src/polylineencoder.cpp
+++ b/src/polylineencoder.cpp
@@ -35,73 +35,24 @@ static const int    s_asciiOffset = 63;
 static const int    s_5bitMask    = 0x1f; // 0b11111 = 31
 static const int    s_6bitMask    = 0x20; // 0b100000 = 32
 
-const std::vector<PolylineEncoder::Point>& PolylineEncoder::Polyline::getPoints() const
+PolylineEncoder::Point::Point(double latitude, double longitude)
+    : m_latitude(std::round(latitude * s_presision) / s_presision)
+    , m_longitude(std::round(longitude * s_presision) / s_presision)
+{}
+
+double PolylineEncoder::Point::latitude() const
 {
-    return m_points;
+    return m_latitude;
 }
 
-void PolylineEncoder::Polyline::addPoint(const Point& point)
+double PolylineEncoder::Point::longitude() const
 {
-    addPoint(std::get<0>(point), std::get<1>(point));
-}
-
-void PolylineEncoder::Polyline::addPoint(double latitude, double longitude)
-{
-    assert(latitude <= 90.0 && latitude >= -90.0);
-    assert(longitude <= 180.0 && longitude >= -180.0);
-
-    m_points.emplace_back(std::round(latitude * s_presision) / s_presision,
-                            std::round(longitude * s_presision) / s_presision);
-}
-
-void PolylineEncoder::Polyline::clear()
-{
-    m_points.clear();
-}
-
-bool PolylineEncoder::Polyline::empty() const
-{
-    return m_points.empty();
-}
-
-size_t PolylineEncoder::Polyline::size() const
-{
-    return m_points.size();
-}
-
-const PolylineEncoder::Point& PolylineEncoder::Polyline::operator[](size_t index) const
-{
-    return m_points[index];
-}
-
-const PolylineEncoder::Point& PolylineEncoder::Polyline::back() const
-{
-    return m_points.back();
-}
-
-PolylineEncoder::Polyline::iterator PolylineEncoder::Polyline::begin()
-{
-    return m_points.begin();
-}
-
-PolylineEncoder::Polyline::iterator PolylineEncoder::Polyline::end()
-{
-    return m_points.end();
-}
-
-PolylineEncoder::Polyline::const_iterator PolylineEncoder::Polyline::begin() const
-{
-    return m_points.begin();
-}
-
-PolylineEncoder::Polyline::const_iterator PolylineEncoder::Polyline::end() const
-{
-    return m_points.end();
+    return m_longitude;
 }
 
 void PolylineEncoder::addPoint(double latitude, double longitude)
 {
-    m_polyline.addPoint(latitude, longitude);
+    m_polyline.emplace_back(latitude, longitude);
 }
 
 std::string PolylineEncoder::encode() const
@@ -148,10 +99,10 @@ std::string PolylineEncoder::encode(const PolylineEncoder::Polyline &polyline)
     double latPrev = .0;
     double lonPrev = .0;
 
-    for (const auto &tuple : polyline)
+    for (const auto &point : polyline)
     {
-      const auto lat = std::get<0>(tuple);
-      const auto lon = std::get<1>(tuple);
+      const auto lat = point.latitude();
+      const auto lon = point.longitude();
 
       // Offset from the previous point
       result.append(encode(lat - latPrev));
@@ -217,10 +168,10 @@ PolylineEncoder::Polyline PolylineEncoder::decode(const std::string &coords)
 
         if (!polyline.empty()) {
             const auto &prevPoint = polyline.back();
-            lat += std::get<0>(prevPoint);
-            lon += std::get<1>(prevPoint);
+            lat += prevPoint.latitude();
+            lon += prevPoint.longitude();
         }
-        polyline.addPoint(lat, lon);
+        polyline.emplace_back(lat, lon);
     }
 
     return polyline;

--- a/src/polylineencoder.h
+++ b/src/polylineencoder.h
@@ -63,7 +63,7 @@ public:
 
 private:
     //! Encodes a single value according to the compression algorithm.
-    static std::string encode(double value);
+    static std::string encode(int32_t e5);
 
     //! Decodes the current decimal value out of string.
     static double decode(const std::string &coords, size_t &i);

--- a/src/polylineencoder.h
+++ b/src/polylineencoder.h
@@ -38,7 +38,32 @@ class PolylineEncoder
 {
 public:
     using Point = std::tuple<double, double>;
-    using Polyline = std::vector<Point>;
+
+    class Polyline
+    {
+    public:
+        using iterator = std::vector<Point>::iterator;
+        using const_iterator = std::vector<Point>::const_iterator;
+
+        const std::vector<Point>& getPoints() const;
+        void addPoint(const Point& point);
+        void addPoint(double latitude, double longitude);
+
+        void clear();
+        bool empty() const;
+        size_t size() const;
+        const Point& operator[](size_t index) const;
+        const Point& back() const;
+
+        iterator begin();
+        iterator end();
+
+        const_iterator begin() const;
+        const_iterator end() const;
+
+    private:
+        std::vector<Point> m_points;
+    };
 
     //! Adds new point with the given \p latitude and \p longitude for encoding.
     void addPoint(double latitude, double longitude);
@@ -63,7 +88,7 @@ public:
 
 private:
     //! Encodes a single value according to the compression algorithm.
-    static std::string encode(int32_t e5);
+    static std::string encode(double value);
 
     //! Decodes the current decimal value out of string.
     static double decode(const std::string &coords, size_t &i);

--- a/src/polylineencoder.h
+++ b/src/polylineencoder.h
@@ -37,33 +37,19 @@
 class PolylineEncoder
 {
 public:
-    using Point = std::tuple<double, double>;
-
-    class Polyline
+    class Point
     {
     public:
-        using iterator = std::vector<Point>::iterator;
-        using const_iterator = std::vector<Point>::const_iterator;
-
-        const std::vector<Point>& getPoints() const;
-        void addPoint(const Point& point);
-        void addPoint(double latitude, double longitude);
-
-        void clear();
-        bool empty() const;
-        size_t size() const;
-        const Point& operator[](size_t index) const;
-        const Point& back() const;
-
-        iterator begin();
-        iterator end();
-
-        const_iterator begin() const;
-        const_iterator end() const;
+        Point(double latitude, double longitude);
+        double latitude() const;
+        double longitude() const;
 
     private:
-        std::vector<Point> m_points;
+        double m_latitude;
+        double m_longitude;
     };
+
+    using Polyline = std::vector<Point>;
 
     //! Adds new point with the given \p latitude and \p longitude for encoding.
     void addPoint(double latitude, double longitude);

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -24,6 +24,16 @@ SOFTWARE.
 
 #include "../src/polylineencoder.cpp"
 
+static bool operator==(const PolylineEncoder::Point& l, const PolylineEncoder::Point& r)
+{
+    return l.longitude() == r.longitude() && r.latitude() == r.latitude();
+}
+
+static bool operator!=(const PolylineEncoder::Point& l, const PolylineEncoder::Point& r)
+{
+    return !(l == r);
+}
+
 static bool test(const std::string &testName,
                  const PolylineEncoder &encoder,
                  const std::string &expected)
@@ -45,8 +55,8 @@ static bool test(const std::string &testName,
         // Compare polylines - they should be equal.
         for (size_t i = 0; i < polyline.size(); ++i)
         {
-            const auto &p1 = polyline[i];
-            const auto &p2 = decodedPolyline[i];
+            const auto &p1 = polyline.at(i);
+            const auto &p2 = decodedPolyline.at(i);
             if (p1 != p2)
             {
                 fprintf(stderr, "%s fails\n", testName.c_str());

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -215,6 +215,22 @@ static bool test13()
     }
 }
 
+static bool test14()
+{
+    // Avoid cumulated error
+    PolylineEncoder encoder;
+    encoder.addPoint(0.0000005, 0.0000005);
+    encoder.addPoint(0.0000000, 0.0000000);
+
+    // Intentionally not use test() function as the precision cut generates difference between encode and decode
+    if (encoder.encode() == "????") {
+        return true;
+    } else {
+        fprintf(stderr, "%s: fails\n", __FUNCTION__);
+        return false;
+    }
+}
+
 int main(int, char**)
 {
     printf("Start PolylineEncoder tests\n");
@@ -232,7 +248,8 @@ int main(int, char**)
     ok = test11() && ok;
     ok = test12() && ok;
     ok = test13() && ok;
-    
+    ok = test14() && ok;
+
     printf("PolylineEncoder tests %s\n", ok ? "passed" : "failed");
     return ok ? 0 : 1;
 }

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -45,8 +45,8 @@ static bool test(const std::string &testName,
         // Compare polylines - they should be equal.
         for (size_t i = 0; i < polyline.size(); ++i)
         {
-            const auto &p1 = polyline.at(i);
-            const auto &p2 = decodedPolyline.at(i);
+            const auto &p1 = polyline[i];
+            const auto &p2 = decodedPolyline[i];
             if (p1 != p2)
             {
                 fprintf(stderr, "%s fails\n", testName.c_str());

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -26,7 +26,8 @@ SOFTWARE.
 
 static bool operator==(const PolylineEncoder::Point& l, const PolylineEncoder::Point& r)
 {
-    return l.longitude() == r.longitude() && r.latitude() == r.latitude();
+    return std::abs(l.longitude() - r.longitude()) < std::numeric_limits<double>::epsilon()
+        && std::abs(l.latitude() - r.latitude()) < std::numeric_limits<double>::epsilon();
 }
 
 static bool operator!=(const PolylineEncoder::Point& l, const PolylineEncoder::Point& r)

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -223,7 +223,25 @@ static bool test14()
     encoder.addPoint(0.0000000, 0.0000000);
 
     // Intentionally not use test() function as the precision cut generates difference between encode and decode
+    // Expectation comes from https://developers.google.com/maps/documentation/utilities/polylineutility
     if (encoder.encode() == "????") {
+        return true;
+    } else {
+        fprintf(stderr, "%s: fails\n", __FUNCTION__);
+        return false;
+    }
+}
+
+static bool test15()
+{
+    // Avoid cumulated error
+    PolylineEncoder encoder;
+    encoder.addPoint(47.231174468994141, 16.62629508972168);
+    encoder.addPoint(47.231208801269531, 16.626440048217773);
+
+    // Intentionally not use test() function as the precision cut generates difference between encode and decode
+    // Expectation comes from https://developers.google.com/maps/documentation/utilities/polylineutility
+    if (encoder.encode() == "yyg_HkindBG[") {
         return true;
     } else {
         fprintf(stderr, "%s: fails\n", __FUNCTION__);
@@ -249,6 +267,7 @@ int main(int, char**)
     ok = test12() && ok;
     ok = test13() && ok;
     ok = test14() && ok;
+    ok = test15() && ok;
 
     printf("PolylineEncoder tests %s\n", ok ? "passed" : "failed");
     return ok ? 0 : 1;


### PR DESCRIPTION
Real life can easily generate test case where the difference between e5 int values is 0 but the difference between the real points is not.
By fixing this issue the usability of the library increases.

By adding CMake as buildsystem the usability of the library inceases