### PR TITLE
Fix a compiler error.

### DIFF
--- a/src/polylineencoder.h
+++ b/src/polylineencoder.h
@@ -206,7 +206,7 @@ std::string PolylineEncoder<Digits>::encode(double value)
 }
 
 template<int Digits>
-std::string PolylineEncoder<Digits>::encode(const PolylineEncoder::Polyline &polyline)
+std::string PolylineEncoder<Digits>::encode(const typename PolylineEncoder::Polyline &polyline)
 {
     std::string result;
 


### PR DESCRIPTION
Some compilers (old once, like MSVC 14.x) don't recognize some types.
Let's explicitly specify that it's a typename.