### PR TITLE
Fix compiler warning due to deprecated double-enum arithmetic

### DIFF
--- a/src/polylineencoder.h
+++ b/src/polylineencoder.h
@@ -103,9 +103,9 @@ public:
     //! Returns polyline decoded from the given \p coordinates string.
     static Polyline decode(const std::string &coordinates);
 
-    enum Precision
+    struct Precision
     {
-        Value = PolylineEncoder<Digits - 1>::Precision::Value * 10
+        static constexpr int Value = PolylineEncoder<Digits - 1>::Precision::Value * 10;
     };
 
 private:
@@ -130,9 +130,9 @@ template<>
 class PolylineEncoder<0>
 {
 public:
-    enum Precision
+    struct Precision
     {
-        Value = 1 // 10^0 = 1
+        static constexpr int Value = 1; // 10^0 = 1
     };
 };
 


### PR DESCRIPTION
This fixes issue #13 and should compile cleanly in C++11 through C++20.