### PR TITLE
Fix the undefined behaviour caused by left shifting of negative values.

### DIFF
--- a/src/polylineencoder.h
+++ b/src/polylineencoder.h
@@ -178,7 +178,9 @@ std::string PolylineEncoder<Digits>::encode(double value)
     int32_t e5 =
         std::round(value * Precision::Value);     // (2)
 
-    if (e5 < 0) {
+    const bool negativeValue = value < 0;
+
+    if (negativeValue) {
         // Negative value must be calculated using
         // its two's complement by inverting the
         // binary value and adding one to the
@@ -191,7 +193,7 @@ std::string PolylineEncoder<Digits>::encode(double value)
 
     e5 <<= 1;                                     // (4)
 
-    if (value < 0) {
+    if (negativeValue) {
         e5 = ~e5;                                 // (5)
     }
 

--- a/src/polylineencoder.h
+++ b/src/polylineencoder.h
@@ -119,10 +119,10 @@ private:
     Polyline m_polyline;
 
     //! Constants
-    static const int s_chunkSize   = 5;
-    static const int s_asciiOffset = 63;
-    static const int s_5bitMask    = 0x1f; // 0b11111 = 31
-    static const int s_6bitMask    = 0x20; // 0b100000 = 32
+    static constexpr const int s_chunkSize   = 5;
+    static constexpr const int s_asciiOffset = 63;
+    static constexpr const int s_5bitMask    = 0x1f; // 0b11111 = 31
+    static constexpr const int s_6bitMask    = 0x20; // 0b100000 = 32
 };
 
 // A bogus class for compile-time precision calculations.

--- a/src/polylineencoder.h
+++ b/src/polylineencoder.h
@@ -176,7 +176,18 @@ template<int Digits>
 std::string PolylineEncoder<Digits>::encode(double value)
 {
     int32_t e5 =
-        std::round(value * Precision::Value); // (2)
+        std::round(value * Precision::Value);     // (2)
+
+    if (e5 < 0) {
+        // Negative value must be calculated using
+        // its two's complement by inverting the
+        // binary value and adding one to the
+        // result                                 // (3)
+
+        e5 *= -1; // Starting with the equivalent positive number;
+        e5 = ~e5; // Inverting (or flipping) all bits – changing every 0 to 1, and every 1 to 0;
+        e5 += 1;  // Adding 1 to the entire inverted number.
+    }
 
     e5 <<= 1;                                     // (4)
 

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -41,6 +41,13 @@ TEST(General, ZeroPoint)
     EXPECT_EQ(encoder.encode(), "??");
 }
 
+TEST(General, NegativeValues)
+{
+    gepaf::PolylineEncoder<> encoder;
+    encoder.addPoint(-77.9832104, -179.9832104);
+    EXPECT_EQ(encoder.encode(), "`b~zM`~oia@");
+}
+
 TEST(General, PolesAndEquator)
 {
     gepaf::PolylineEncoder<> encoder;


### PR DESCRIPTION
Properly handle encoding of the signed values. According to the algorithm (step 3, https://developers.google.com/maps/documentation/utilities/polylinealgorithm) negative values must be calculated using their two's complement.

fixed #15