### PR TITLE
Add more generic and less memory consuming encone fuction + update Gtest requirements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.9)
 
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 
 option(ENABLE_TESTING "Enable unit test build" OFF)
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ from the terminal, assuming that compiler and environment are already configured
 ##### Linux (gcc)
 ```
 cd test
-g++ -std=c++11 -I..\src main.cpp -o test
+g++ -std=c++14 -I..\src main.cpp -o test
 ./test
 ```
 

--- a/src/polylineencoder.h
+++ b/src/polylineencoder.h
@@ -100,6 +100,9 @@ public:
     //! Returns the result of encoding of the given polyline.
     static std::string encode(const Polyline &polyline);
 
+    template <typename T>
+    static std::string encodeList(const T *data, size_t list_length, double T::*latitude, double T::*longitude);
+
     //! Returns polyline decoded from the given \p coordinates string.
     static Polyline decode(const std::string &coordinates);
 
@@ -230,6 +233,32 @@ std::string PolylineEncoder<Digits>::encode(const typename PolylineEncoder::Poly
     for (const auto &point : polyline) {
         const auto lat = point.latitude();
         const auto lon = point.longitude();
+
+        // Offset from the previous point
+        result.append(encode(lat - latPrev));
+        result.append(encode(lon - lonPrev));
+
+        latPrev = lat;
+        lonPrev = lon;
+    }
+
+    return result;
+}
+
+template <int Digits>
+template <typename T>
+std::string PolylineEncoder<Digits>::encodeList(const T *data, size_t list_length, double T::*latitude, double T::*longitude)
+{
+    std::string result;
+
+    double latPrev = .0;
+    double lonPrev = .0;
+
+    // for (const auto &idx : remained_index)
+    for (size_t idx =0; idx< list_length; idx++)
+    {
+        const auto lat = data[idx].*latitude;
+        const auto lon = data[idx].*longitude;
 
         // Offset from the previous point
         result.append(encode(lat - latPrev));

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -59,6 +59,34 @@ TEST(General, PolesAndEquator)
     EXPECT_EQ(encoder.encode(), "~bidP~fsia@_cidP_gsia@_cidP_gsia@");
 }
 
+TEST(General, EncodeGenericList)
+{
+
+    class DummyPoint {
+    public:
+        DummyPoint(double t_x, double t_y): x(t_x), y(t_y), speed(0), heading(0){}
+
+        double x;
+        double y;
+        unsigned short speed;
+        float heading;
+
+    };
+
+    gepaf::PolylineEncoder<> encoder;
+
+    DummyPoint dp[] = {
+            DummyPoint{-90.0, -180.0},
+            DummyPoint{.0, .0},
+            DummyPoint{90.0, 180.0}
+    };
+    auto result = encoder.encodeList(dp,3, &DummyPoint::x, &DummyPoint::y);
+    printf("%s\n", result.c_str());
+
+    // Poles and equator.
+    EXPECT_EQ(result.c_str(), "~bidP~fsia@_cidP_gsia@_cidP_gsia@");
+}
+
 TEST(General, EmptyList)
 {
     // Empty list of points.

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -75,16 +75,15 @@ TEST(General, EncodeGenericList)
 
     gepaf::PolylineEncoder<> encoder;
 
+    // List of DummyPoint for testing purpose 
     DummyPoint dp[] = {
             DummyPoint{-90.0, -180.0},
             DummyPoint{.0, .0},
             DummyPoint{90.0, 180.0}
     };
     auto result = encoder.encodeList(dp,3, &DummyPoint::x, &DummyPoint::y);
-    printf("%s\n", result.c_str());
 
-    // Poles and equator.
-    EXPECT_EQ(result.c_str(), "~bidP~fsia@_cidP_gsia@_cidP_gsia@");
+    EXPECT_EQ(result, "~bidP~fsia@_cidP_gsia@_cidP_gsia@");
 }
 
 TEST(General, EmptyList)


### PR DESCRIPTION
Hello, many thanks, I have learned so much from your code. 
A problem that I had with it was that I have a small amount of memory, so adding each point to a `std::vector<Point>` isn't efficient in my case where I am receiving an array of Some type **`T`** with variable length between **_300_** and **_600_** `T `objects in it. so I added a member function to the `PolylineEncoder` class that takes a list of Generic type with the corresponding length and also **`pointers to members`** for the **`latitude`** and **`longitude`**.
In this way, this would be more efficient and easier to use the library on a more memory-constrained device with more freedom for types that didn't have functions for **`latitude/longitude`** ( like in my case, **protoc** generated types).

also after **`v1.12.1 of GTest`** on **` Jun 30, 2022`** the support for **`C++11`** was dropped, and newer versions require at least **`C++14`**, so I think it is a good idea to update the C++ requirement for GTest. 